### PR TITLE
Feature/asg term and node age roll

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY lib ./lib
 COPY config.py eks_rolling_update.py ./
 
-ENTRYPOINT ["python", "eks_rolling_update.py"]
+CMD ["python", "eks_rolling_update.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY lib ./lib
 COPY config.py eks_rolling_update.py ./
 
-CMD ["python", "eks_rolling_update.py"]
+ENTRYPOINT ["python", "eks_rolling_update.py"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ eks-rolling-update.py -c my-eks-cluster
 | GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                              | 20                                       |
 | BETWEEN_NODES_WAIT        | Number of seconds to wait after removing a node before continuing on                                                  | 0                                        |
 | RUN_MODE                  | See Run Modes section below                                                                                           | 1                                        |
+| FRESH_NODE_DAYS            | The max age each node expected to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node.                                                                                            | 6                                        |
 | DRY_RUN                   | If True, only a query will be run to determine which worker nodes are outdated without running an update operation    | False                                    |
 | EXTRA_DRAIN_ARGS          | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
 
@@ -112,11 +113,12 @@ There are a number of different values which can be set for the `RUN_MODE` envir
 
 `1` is the default.
 
-| Mode Number   | Description                                                                                     |
-|---------------|-------------------------------------------------------------------------------------------------|
-| 1             | Scale up and cordon the outdated nodes of each ASG one-by-one, just before we drain them.       |
-| 2             | Scale up and cordon the outdated nodes of all ASGs all at once at the beginning of the run.     |
-| 3             | Cordon the outdated nodes of all ASGs at the beginning of the run but scale each ASG one-by-one.|
+| Mode Number   | Description                                                                                            |
+|---------------|--------------------------------------------------------------------------------------------------------|
+| 1             | Scale up and cordon the outdated nodes of each ASG one-by-one, just before we drain them.              |
+| 2             | Scale up and cordon the outdated nodes of all ASGs all at once at the beginning of the run.            |
+| 3             | Cordon the outdated nodes of all ASGs at the beginning of the run but scale each ASG one-by-one.       |
+| 4             | Roll EKS nodes based on age instead of launch config (works with `FRESH_NODE_DAYS` default to 6 days) .|
 
 Each of them have different advantages and disadvantages.
 * Scaling up all ASGs at once may cause AWS EC2 instance limits to be exceeded

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ There are a number of different values which can be set for the `RUN_MODE` envir
 | 1             | Scale up and cordon the outdated nodes of each ASG one-by-one, just before we drain them.              |
 | 2             | Scale up and cordon the outdated nodes of all ASGs all at once at the beginning of the run.            |
 | 3             | Cordon the outdated nodes of all ASGs at the beginning of the run but scale each ASG one-by-one.       |
-| 4             | Roll EKS nodes based on age instead of launch config (works with `FRESH_NODE_DAYS` default to 6 days.  |
+| 4             | Roll EKS nodes based on age instead of launch config (works with `FRESH_NODE_DAYS` default to 6 days). |
 
 Each of them have different advantages and disadvantages.
 * Scaling up all ASGs at once may cause AWS EC2 instance limits to be exceeded

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ There are a number of different values which can be set for the `RUN_MODE` envir
 | 1             | Scale up and cordon the outdated nodes of each ASG one-by-one, just before we drain them.              |
 | 2             | Scale up and cordon the outdated nodes of all ASGs all at once at the beginning of the run.            |
 | 3             | Cordon the outdated nodes of all ASGs at the beginning of the run but scale each ASG one-by-one.       |
-| 4             | Roll EKS nodes based on age instead of launch config (works with `FRESH_NODE_DAYS` default to 6 days) .|
+| 4             | Roll EKS nodes based on age instead of launch config (works with `FRESH_NODE_DAYS` default to 6 days.  |
 
 Each of them have different advantages and disadvantages.
 * Scaling up all ASGs at once may cause AWS EC2 instance limits to be exceeded

--- a/config.py
+++ b/config.py
@@ -21,5 +21,6 @@ app_config = {
     'RUN_MODE': int(os.getenv('RUN_MODE', 1)),
     'DRY_RUN': str_to_bool(os.getenv('DRY_RUN', False)),
     'EXCLUDE_NODE_LABEL_KEY': 'spotinst.io/node-lifecycle',
-    'EXTRA_DRAIN_ARGS': os.getenv('EXTRA_DRAIN_ARGS', '').split()
+    'EXTRA_DRAIN_ARGS': os.getenv('EXTRA_DRAIN_ARGS', '').split(),
+    'FRESH_NODE_DAYS': int(os.getenv('FRESH_NODE_DAYS', 6))
 }

--- a/eks_rolling_update.py
+++ b/eks_rolling_update.py
@@ -5,8 +5,8 @@ import shutil
 from config import app_config
 from lib.logger import logger
 from lib.aws import is_asg_scaled, is_asg_healthy, instance_terminated, get_asg_tag, modify_aws_autoscaling, \
-    count_all_cluster_instances, save_asg_tags, get_asgs, terminate_instance, scale_asg, plan_asgs, delete_asg_tags, \
-    detach_instance, instance_detached
+    count_all_cluster_instances, save_asg_tags, get_asgs, terminate_instance_in_asg, scale_asg, plan_asgs, delete_asg_tags, \
+    instance_detached, plan_asgs_older_nodes
 from lib.k8s import k8s_nodes_count, k8s_nodes_ready, get_k8s_nodes, modify_k8s_autoscaler, get_node_by_instance_id, \
     drain_node, delete_node, cordon_node
 from lib.exceptions import RollingUpdateException
@@ -118,7 +118,11 @@ def scale_up_asg(cluster_name, asg, count):
 def update_asgs(asgs, cluster_name):
     run_mode = int(app_config['RUN_MODE'])
 
-    asg_outdated_instance_dict = plan_asgs(asgs)
+    if run_mode == 4:
+        asg_outdated_instance_dict = plan_asgs_older_nodes(asgs)
+
+    else:
+        asg_outdated_instance_dict = plan_asgs(asgs)
 
     asg_original_state_dict = {}
 
@@ -151,12 +155,12 @@ def update_asgs(asgs, cluster_name):
         outdated_instances, asg = asg_tuple
         outdated_instance_count = len(outdated_instances)
 
-        if (run_mode == 1) or (run_mode == 3):
+        if (run_mode == 1) or (run_mode == 3) or (run_mode == 4):
             logger.info(
                 f'Setting the scale of ASG {asg_name} based on {outdated_instance_count} outdated instances.')
             asg_original_state_dict[asg_name] = scale_up_asg(cluster_name, asg, outdated_instance_count)
 
-        if run_mode == 1:
+        if (run_mode == 1) or (run_mode == 4):
             for outdated in outdated_instances:
                 node_name = ""
                 try:
@@ -181,12 +185,16 @@ def update_asgs(asgs, cluster_name):
                 node_name = get_node_by_instance_id(k8s_nodes, outdated['InstanceId'])
                 drain_node(node_name)
                 delete_node(node_name)
-                terminate_instance(outdated['InstanceId'])
+                terminate_instance_in_asg(outdated['InstanceId'])
                 if not instance_terminated(outdated['InstanceId']):
                     raise Exception('Instance is failing to terminate. Cancelling out.')
-                detach_instance(outdated['InstanceId'], asg_name)
-                if not instance_detached(outdated['InstanceId']):
-                    raise Exception('Instance is failing to detach from ASG. Cancelling out.')
+
+                #terminate_instance(outdated['InstanceId'])
+                #if not instance_terminated(outdated['InstanceId']):
+                #    raise Exception('Instance is failing to terminate. Cancelling out.')
+                #detach_instance(outdated['InstanceId'], asg_name)
+                #if not instance_detached(outdated['InstanceId']):
+                #    raise Exception('Instance is failing to detach from ASG. Cancelling out.')
 
                 between_nodes_wait = int(app_config['BETWEEN_NODES_WAIT'])
                 if between_nodes_wait != 0:
@@ -224,8 +232,15 @@ if __name__ == "__main__":
         quit(1)
     filtered_asgs = get_asgs(args.cluster_name)
     # perform a dry run
-    if args.plan:
+
+    run_mode = int(app_config['RUN_MODE'])
+
+    if args.plan and (run_mode == 4):
+        plan_asgs_older_nodes(filtered_asgs)
+
+    elif args.plan:
         plan_asgs(filtered_asgs)
+
     else:
         # perform real update
         if app_config['K8S_AUTOSCALER_ENABLED']:

--- a/eks_rolling_update.py
+++ b/eks_rolling_update.py
@@ -11,7 +11,6 @@ from lib.k8s import k8s_nodes_count, k8s_nodes_ready, get_k8s_nodes, modify_k8s_
     drain_node, delete_node, cordon_node
 from lib.exceptions import RollingUpdateException
 
-
 def validate_cluster_health(asg_name, new_desired_asg_capacity, desired_k8s_node_count, ):
     cluster_healthy = False
     # check if asg has enough nodes first before checking instance health
@@ -188,13 +187,6 @@ def update_asgs(asgs, cluster_name):
                 terminate_instance_in_asg(outdated['InstanceId'])
                 if not instance_terminated(outdated['InstanceId']):
                     raise Exception('Instance is failing to terminate. Cancelling out.')
-
-                #terminate_instance(outdated['InstanceId'])
-                #if not instance_terminated(outdated['InstanceId']):
-                #    raise Exception('Instance is failing to terminate. Cancelling out.')
-                #detach_instance(outdated['InstanceId'], asg_name)
-                #if not instance_detached(outdated['InstanceId']):
-                #    raise Exception('Instance is failing to detach from ASG. Cancelling out.')
 
                 between_nodes_wait = int(app_config['BETWEEN_NODES_WAIT'])
                 if between_nodes_wait != 0:

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -45,7 +45,7 @@ def terminate_instance_in_asg(instance_id):
                 ShouldDecrementDesiredCapacity=True
             )
             if response['ResponseMetadata']['HTTPStatusCode'] == requests.codes.ok:
-                logger.info('Termination singal for instance is successfully sent.')
+                logger.info('Termination signal for instance is successfully sent.')
             else:
                 logger.info('Termination singal for instance has failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))
                 raise Exception('Termination of instance failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -47,7 +47,7 @@ def terminate_instance_in_asg(instance_id):
             if response['ResponseMetadata']['HTTPStatusCode'] == requests.codes.ok:
                 logger.info('Termination signal for instance is successfully sent.')
             else:
-                logger.info('Termination singal for instance has failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))
+                logger.info('Termination signal for instance has failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))
                 raise Exception('Termination of instance failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))
 
         except client.exceptions.ClientError as e:
@@ -257,7 +257,7 @@ def instance_outdated_launchtemplate(instance_obj, asg_lt_name, asg_lt_version):
     return False
 
 
-def older_instance (instance_id, days_fresh):
+def instance_outdated_age (instance_id, days_fresh):
 
     response = ec2_client.describe_instances(
         InstanceIds=[
@@ -267,7 +267,10 @@ def older_instance (instance_id, days_fresh):
 
     instance_launch_time = response['Reservations'][0]['Instances'][0]['LaunchTime']
 
+    #gets the age of a node by days only:
     instance_age = ((datetime.datetime.now(instance_launch_time.tzinfo) - instance_launch_time).days)
+    
+    #gets the remaining age of a node in seconds (e.g. if node is y days and x seconds old this will only retrieve the x seconds):
     instance_age_remainder = ((datetime.datetime.now(instance_launch_time.tzinfo) - instance_launch_time).seconds)
 
     if instance_age > days_fresh:
@@ -365,7 +368,7 @@ def plan_asgs_older_nodes(asgs):
         # return a list of outdated instances
         outdated_instances = []
         for instance in instances:
-            if older_instance(instance['InstanceId'], days_fresh):
+            if instance_outdated_age(instance['InstanceId'], days_fresh):
                     outdated_instances.append(instance)
         logger.info('Found {} outdated instances'.format(
             len(outdated_instances))


### PR DESCRIPTION
Adding a mode 4 to the script which aims to update (roll) nodes based on each ec2 instance age (e.g. older than 6 days).

This will have the exact same functionality expectation as mode 1 except for evaluating outdated nodes.

Another change is to also remove the requirement to call `terminate_instances` from EC2 client and instead performing termination via Autoscaling client using `terminate_instance_in_auto_scaling_group` which ensures IAM roles can be more narrow to an ASG ARN and also eliminate the need to detach instances from ASGs.

